### PR TITLE
Add bin/releases file

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+# bin/release <build-dir>


### PR DESCRIPTION
Encountered this error while futzing with this build pack:

```
...
-----> Fetching custom git buildpack... done
-----> Multipack app detected
=====> Downloading Buildpack: https://github.com/gregburek/heroku-buildpack-runit.git
chmod: cannot access `/tmp/buildpackXgaUN/bin/release': No such file or directory

 !     Push rejected, failed to compile Multipack app

...
```

This PR adds a nominally blank releases file, which allows the build to succeed.
