### PR TITLE
fix 301 redirect issue with kernel.org URL

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -19,12 +19,12 @@ mkdir -p $SW_DIR
 install() {
   DEB_URL=$1
   DIR=$(mktemp -d)
-  curl -f $DEB_URL -o $DIR/deb
+  curl -Lf $DEB_URL -o $DIR/deb
   dpkg-deb -x $DIR/deb $SW_DIR
   rm -rf $DIR
 }
 
-install http://mirrors.kernel.org/ubuntu/pool/universe/r/runit/runit_2.1.1-6.2ubuntu3_amd64.deb
+install https://mirrors.edge.kernel.org/ubuntu/pool/universe/r/runit/runit_2.1.1-6.2ubuntu3_amd64.deb
 
 mkdir -p .profile.d
 cat > .profile.d/runit.sh <<EOF


### PR DESCRIPTION
Hey Dan, ❤️ this package. I use it to deploy an app for my startup.

Today, our deploys started failing with 

```
remote:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
remote:                                  Dload  Upload   Total   Spent    Left  Speed
remote: 100   178  100   178    0     0   1278      0 --:--:-- --:--:-- --:--:--  1280
remote: dpkg-deb: error: '/tmp/tmp.bcLemZL57a/deb' is not a debian format archive
```

I dug a little deeper, and found that it was simply that the URL for the runit package had been moved, and the curl command wasn't set to follow redirects.

So this PR does two things:

1. Changes the kernel.org URL to the location specified in the 301 redirect
2. Add the `-L` flag to curl so that it will follow future redirects

Cheers!

EDIT: Fixes #12
