### PR TITLE
Revert "Use a different package host"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,7 +24,7 @@ install() {
   rm -rf $DIR
 }
 
-install http://archive.ubuntu.com/ubuntu/pool/universe/r/runit/runit_2.1.1-6.2ubuntu3_amd64.deb
+install https://mirrors.edge.kernel.org/ubuntu/pool/universe/r/runit/runit_2.1.1-6.2ubuntu3_amd64.deb
 
 mkdir -p .profile.d
 cat > .profile.d/runit.sh <<EOF


### PR DESCRIPTION
This reverts commit b3c7efca29156afd288632b6cd4482c3bc4b44d2.

The original package host has renewed its cert. Unfortunately, the new package I added does not have the same folder structure which causes the bin not being copied over? The ~/bin does not have the files from the `buildpack/bin` anymore.